### PR TITLE
Handle build failure

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -196,18 +196,37 @@ exports.compile = function (options, complete) {
 			}
 		},
 
-        /**
-         * monkeypatch child_process.js so nexejs knows when it is a forked process
-         */
-        function monkeyPatchChildProc(next) {
-            _monkeyPatchChildProcess(nodeCompiler, next);
-        },
+		/**
+		 * monkeypatch child_process.js so nexejs knows when it is a forked process
+		 */
+		function monkeyPatchChildProc(next) {
+			_monkeyPatchChildProcess(nodeCompiler, next);
+		},
+
+		/**
+		 * If an old compiled executable exists in the Release directory, delete it.
+		 * This lets us see if the build failed by checking the existence of this file later.
+		 */
+
+		function cleanUpOldExecutable (next) {
+			fs.unlink(nodeCompiler.releasePath, function (err) {
+				if (err) {
+					if (err.code === "ENOENT") {
+						next();
+					} else {
+						throw err;
+					}
+				} else {
+					next();
+				}
+			});
+		},
 
 		/**
 		 * compile the node application
 		 */
 
-		function makeExe (next) {
+		function makeExecutable (next) {
 			if(isWin) {
 				_log("vcbuild [make stage]");
 			} else {
@@ -222,6 +241,25 @@ exports.compile = function (options, complete) {
 
 		function makeOutputDirectory (next) {
 			mkdirp(path.dirname(options.output), function(){ next(); });
+		},
+
+		/**
+		 * Verify that the executable was compiled successfully
+		 */
+
+		function checkThatExecutableExists (next) {
+			fs.access(nodeCompiler.releasePath, function (err) {
+				if (err) {
+					_log("error",
+						"The release executable has not been generated. " +
+						"This indicates a failure in the build process. " +
+						"There is likely additional information above."
+					);
+					throw new Error("The release executable was not built ('" + nodeCompiler.releasePath + "')");
+				} else {
+					next();
+				}
+			});
 		},
 
 		/**


### PR DESCRIPTION
Fixes https://github.com/jaredallard/nexe/issues/134

Removes the possibility of a silent build failure (if the executable has already been compiled)

The error now looks like this:
![The release executable has not been generated. This indicates a failure in the build process. There is likely additional information above.](https://cloud.githubusercontent.com/assets/3630663/9906140/c6c33ba0-5c56-11e5-8e95-6a210356441f.png)