### PR TITLE
proxy browserResolve, fix `child_process.fork` results in bad option, efforts on commander.js compatibility.

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -21,10 +21,11 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  **/
-var mdeps = require("module-deps"),
-through   = require("through"),
-async     = require("async"),
-builtins = require("builtins");
+var mdeps      = require("module-deps"),
+browserResolve = require("browser-resolve"),
+through        = require("through"),
+async          = require("async"),
+builtins       = require("builtins");
 
 var _log     = require("./log");
 
@@ -43,6 +44,10 @@ function bundle (input, complete) {
 
 
       var md = mdeps({
+        resolve: function (id, options, callback) {
+          options.browser = "main";
+          return browserResolve(id, options, callback);
+        },
         xtransform: function (tr, file) {
 
           var buffer = [];
@@ -139,6 +144,8 @@ var loader = function (deps, key) {
   var pathModule = global.require("path");
   var darr = [];
   var dir = global.require("path").dirname(process.execPath);
+
+  process.argv[1] = key;
 
   var argv3 = process.argv[3];
   if (argv3) {

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -143,12 +143,12 @@ function bundle (input, complete) {
 var loader = function (deps, key) {
   var pathModule = global.require("path");
   var darr = [];
-  var dir = global.require("path").dirname(process.execPath);
+  var dir = pathModule.dirname(process.execPath);
 
   process.argv[1] = key;
 
   var argv3 = process.argv[3];
-  if (argv3) {
+  if (argv3 && /^(?!\/|\w+:)/.test(argv3)) {
     argv3 = pathModule.relative(pathModule.dirname(process.execPath), argv3);
     argv3 = pathModule.resolve(pathModule.dirname(key), argv3);
   }

--- a/lib/exe.js
+++ b/lib/exe.js
@@ -555,7 +555,13 @@ function _monkeyPatchMainJs (compiler, complete) {
 			return ~content.indexOf("nexe");
 		},
 		function (content, next) {
-			next(null, content.replace(/\(function\(process\) \{/,'(function(process) {\n  process._eval = \'require("nexe");\';\n  process.argv.splice(1, 0, "nexe.js");\n'))
+			next(null, content.replace(/\(function\(process\) \{/,'\
+(function(process) {\n\
+  process._eval = \'require("nexe");\';\n\
+  if (process.argv[1] !== "nexe.js") {\n\
+    process.argv.splice(1, 0, "nexe.js");\n\
+  }\n\
+'))
 		},
 		complete
 	);
@@ -572,7 +578,7 @@ function _monkeyPatchChildProcess(compiler, complete) {
             return ~content.indexOf("--child_process");
         },
         function (content, next) {
-            next(null, content.replace(/return spawn\(/, 'args.unshift("--child_process");\n  return spawn('));
+            next(null, content.replace(/return spawn\(/, 'args.unshift("nexe.js", "--child_process");\n  return spawn('));
         },
         complete
     );

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "async": "1.2.1",
+    "browser-resolve": "^1.10.0",
     "builtins": "1.0.1",
     "colors": "^1.0.3",
     "glob": "^5.0.5",
@@ -43,7 +44,7 @@
       "ignoreFlags": true
     }
   },
-  "preferGlobal": "true",
+  "preferGlobal": true,
   "bin": {
     "nexe": "./bin/nexe"
   }


### PR DESCRIPTION
Related pull request https://github.com/tj/commander.js/pull/460

Besides the fix and problems with commander.js I mentioned in #120 , I am trying to proxy browserResolve in `module-deps` to prevent it from adding "browser" field as polyfill (typically `form-data` module as the dependency of `request` module).

Sorry I don't have much time to split these commits. Feel free to let me know if there's something improper.