### PR TITLE
add nodeConfigureArgs and nodeMakeArgs from package.json

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -138,7 +138,7 @@ exports.compile = function (options, complete) {
 		 * first download node
 		 */
 		function downloadNode (next) {
-			_downloadNode(version, options.nodeTempDir, next);
+			_downloadNode(version, options.nodeTempDir, options.nodeConfigureArgs, options.nodeMakeArgs, next);
 		},
 
 		/**
@@ -289,14 +289,14 @@ exports.compile = function (options, complete) {
  * @param {function} complete, callback
  */
 
-function _downloadNode (version, directory, complete) {
+function _downloadNode (version, directory, nodeConfigureArgs, nodeMakeArgs, complete) {
 
 	var nodeFileDir = path.resolve(path.join(directory, framework, version)), // fixes #107, was process.cwd(), + rest.
 	nodeFilePath    = path.resolve(path.join(nodeFileDir, framework + "-" + version + ".tar.gz"));
 
 
 	// might already be downloaded, and unzipped
-	if (_getNodeCompiler(nodeFileDir, complete)) {
+	if (_getNodeCompiler(nodeFileDir, nodeConfigureArgs, nodeMakeArgs, complete)) {
 		return;
 	}
 
@@ -373,7 +373,7 @@ function _downloadNode (version, directory, complete) {
 		 */
 
 		function (next, type) {
-			_getNodeCompiler(nodeFileDir, next, type)
+			_getNodeCompiler(nodeFileDir, nodeConfigureArgs, nodeMakeArgs, next, type)
 		},
 
 	], complete);
@@ -384,7 +384,7 @@ function _downloadNode (version, directory, complete) {
  * it.
  */
 
-function _getNodeCompiler (nodeFileDir, complete, type) {
+function _getNodeCompiler (nodeFileDir, nodeConfigureArgs, nodeMakeArgs, complete, type) {
 	var dir = _getFirstDirectory(nodeFileDir);
 
 	// standard
@@ -432,9 +432,9 @@ function _getNodeCompiler (nodeFileDir, complete, type) {
 				make: function (next) {
 					var cfg = "./configure", configure;
 					if(isPy !== "python") {
-						configure = spawn(isPy, [cfg], { cwd: dir });
+						configure = spawn(isPy, [cfg].concat(nodeConfigureArgs), { cwd: dir });
 					} else {
-						configure = spawn(cfg, [], { cwd: dir });
+						configure = spawn(cfg, nodeConfigureArgs, { cwd: dir });
 					}
 
 					// local function, move to top eventually
@@ -486,7 +486,7 @@ function _getNodeCompiler (nodeFileDir, complete, type) {
 						if (os.platform().match(/bsd$/) != null) {
 							platformMake = "gmake";
 						}
-						var make = spawn(platformMake, [], { cwd: dir });
+						var make = spawn(platformMake, nodeMakeArgs, { cwd: dir });
 						make.stdout.pipe(process.stdout);
 						make.stderr.pipe(process.stderr);
 						make.on("close", function () {
@@ -698,6 +698,8 @@ exports.package = function(path, options) {
 		input: (_package.nexe.input || options.i),
 		output: (_package.nexe.output || options.o),
 		flags: (_package.nexe.runtime.ignoreFlags || options.f),
+		nodeConfigureArgs: (_package.nexe.runtime.nodeConfigureArgs || []),
+		nodeMakeArgs: (_package.nexe.runtime.nodeMakeArgs || []),
 		resourceFiles: (_package.nexe.resourceFiles),
 		nodeVersion: (_package.nexe.runtime.version || options.r),
 		python: (_package.nexe.python || options.p),


### PR DESCRIPTION
example:

        "runtime": {
            "framework": "nodejs",
            "version": "5.0.0",
            "ignoreFlags": true,
            "nodeConfigureArgs": ["--fully-static"],
            "nodeMakeArgs": ["-j","4"]
        }

there is no check if those flags change, which means
if they are changed you must rm -rf the temp directory

will probably push a commit that writes a checksum of them
in the node temp directory so it knows when it is invalid, but not surei f that is a good idea

I did not add support for those as `argv` options, because it seems it can be quite confusing what goes where.
Anyway, please consider this pull request as more of a "feature request", and this is just my
hacky way of implementing what I needed.

