### PR TITLE
Make checkThatExecutableExists backwards compatible

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -248,8 +248,8 @@ exports.compile = function (options, complete) {
 		 */
 
 		function checkThatExecutableExists (next) {
-			fs.access(nodeCompiler.releasePath, function (err) {
-				if (err) {
+			fs.exists(nodeCompiler.releasePath, function (exists) {
+				if (!exists) {
 					_log("error",
 						"The release executable has not been generated. " +
 						"This indicates a failure in the build process. " +


### PR DESCRIPTION
To enable operation with Node.js 0.10.x