### PR TITLE
fix(exe): remove assignation on undefined variable

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -531,7 +531,6 @@ function _getNodeCompiler(nodeFileDir, nodeConfigureArgs, nodeMakeArgs, complete
                   encoding: 'utf8'
                 }); // write to file
 
-                pv = undefined;
               } else if (stat.isDirectory()) {
                 // must be dir?
                 // skip tests because we don't need them here


### PR DESCRIPTION
This makes my build fails since `pv` is undefined and you try to assign it the `undefined` value. I'm maybe guessing that `pv` should be `py`, but since the variable is not used anywhere after, I think we could safely remove this.