### PR TITLE
Fixes "Native module not found" problem

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -673,13 +673,17 @@ function _monkeyPatchMainJs(compiler, complete) {
       return ~content.indexOf("nexe");
     },
     function(content, next) {
-      next(null, content.replace(/\(function\(process\) \{/, '\
+	  content = content.replace(/\(function\(process\) \{/, '\
 (function(process) {\n\
-  process._eval = \'require("nexe");\';\n\
   if (process.argv[1] !== "nexe.js") {\n\
     process.argv.splice(1, 0, "nexe.js");\n\
   }\n\
-'))
+')
+      content = content.replace('function startup() {', '\
+function startup() {\n\
+    process._eval = NativeModule.getSource("nexe");\n\
+')
+      next(null, content)
     },
     complete
   );


### PR DESCRIPTION
This fixes "Native module not found" problem when using excluded modules. With this fix nodejs will treat nexe.js same way as one would use --eval parameter. Otherwise nodejs will thead nexe.js as a NativeModule and for that reason it will ignore excluded modules.

Tested with nodejs 5.9.1 on Windows