### PR TITLE
#243 - hotfix call browserify.require(file, opts)

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -46,9 +46,8 @@ function bundle(input, nc, options, complete) {
   const mapfile    = options.output+'.map';
   let ws           = fs.createWriteStream(bundlePath);
 
-
   const igv = '__filename,__dirname,_process';
-  let insertGlobalVars = {},
+  let insertGlobalVars = { isNexe: true },
       wantedGlobalVars = igv.split(',');
 
   // parse insertGlobalVars.

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -89,9 +89,15 @@ function bundle(input, nc, options, complete) {
     for (let i = 0; i < options.browserifyRequires.length; i++) {
       let lib = options.browserifyRequires[i];
       let name = lib.file || lib; // for  object format.
+      // if `lib` is object then fetch all params without `file`
+      // otherwise returns empty object
+      let opts = (lib instanceof Object) && Object.keys(lib)
+        .filter((key) => key !== 'file')
+        .reduce((acc, key) => { return acc[key] = lib[key], acc }, {})
+        || {};
 
       _log('Force including \'%s\' in browserify bundle', name);
-      bproc.require(lib);
+      bproc.require(lib, opts);
     }
   }
 


### PR DESCRIPTION
Problem - Issue #243 

[b.require(file, opts)](https://github.com/substack/node-browserify#brequirefile-opts)

Use the `expose` property of opts to specify a custom dependency name. `require('./vendor/angular/angular.js', {expose: 'angular'})` enables `require('angular')`