### PR TITLE
startupSnapshot: need to generate python raw strings because of windows paths

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -683,7 +683,7 @@ function _monkeyPatchConfigure(compiler, complete, options) {
       function(content, next) {
         next(null, content.replace(
           "def configure_v8(o):",
-          `def configure_v8(o):\n  o['variables']['embed_script'] = '${snapshotPath}'\n  o['variables']['warmup_script'] = '${snapshotPath}'`));
+          `def configure_v8(o):\n  o['variables']['embed_script'] = r'${snapshotPath}'\n  o['variables']['warmup_script'] = r'${snapshotPath}'`));
       },
       complete
     )


### PR DESCRIPTION
or else in paths such as `C:\target\foo` the `\t` would be replaced by a tab, causing very weird errors.
